### PR TITLE
BFB-62: Analytics for checkpoints

### DIFF
--- a/Assets/_BForBoss/Scripts/Managers/CheckpointManager.cs
+++ b/Assets/_BForBoss/Scripts/Managers/CheckpointManager.cs
@@ -12,6 +12,8 @@ namespace BForBoss
         [SerializeField] private Checkpoint _spawnPoint = null;
         [SerializeField] private Checkpoint[] _checkpoints = null;
         [SerializeField] private Checkpoint _endPoint = null;
+        private TimeManagerViewModel _timeManagerViewModel = null;
+        private readonly PerigonAnalytics _perigonAnalytics = PerigonAnalytics.Instance;
         private Checkpoint _activeCheckpoint = null;
         
         private DetectInput _detectInput = null;
@@ -19,7 +21,7 @@ namespace BForBoss
         public Vector3 CheckpointPosition => _activeCheckpoint == null ? _spawnPoint.transform.position : _activeCheckpoint.transform.position;
         public Quaternion CheckpointRotation => _activeCheckpoint == null ? _spawnPoint.transform.rotation : _activeCheckpoint.transform.rotation;
 
-        public void Initialize(DetectInput detectInput)
+        public void Initialize(DetectInput detectInput, TimeManagerViewModel timeManagerViewModel)
         {
             _detectInput = detectInput;
             if (_checkpoints.IsNullOrEmpty())
@@ -40,6 +42,7 @@ namespace BForBoss
             }
 
             _endPoint.OnEnterArea += OnEnteredLastPoint;
+            _timeManagerViewModel = timeManagerViewModel;
         }
 
         public void Reset()
@@ -57,6 +60,8 @@ namespace BForBoss
             _detectInput.Detect();
             _activeCheckpoint = checkpoint;
             _activeCheckpoint.SetCheckpoint();
+            
+            _perigonAnalytics.LogCheckpointData(_timeManagerViewModel.CurrentGameTime, _activeCheckpoint.name);
         }
 
         private void OnEnteredLastPoint(Checkpoint _)

--- a/Assets/_BForBoss/Scripts/Managers/CheckpointManager.cs
+++ b/Assets/_BForBoss/Scripts/Managers/CheckpointManager.cs
@@ -61,7 +61,7 @@ namespace BForBoss
             _activeCheckpoint = checkpoint;
             _activeCheckpoint.SetCheckpoint();
             
-            _perigonAnalytics.LogCheckpointData(_timeManagerViewModel.CurrentGameTime, _activeCheckpoint.name);
+            _perigonAnalytics.LogCheckpointEvent(_timeManagerViewModel.CurrentGameTime, _activeCheckpoint.name);
         }
 
         private void OnEnteredLastPoint(Checkpoint _)

--- a/Assets/_BForBoss/Scripts/Managers/WorldManager.cs
+++ b/Assets/_BForBoss/Scripts/Managers/WorldManager.cs
@@ -59,7 +59,7 @@ namespace BForBoss
         private void Start()
         {
             _player.Initialize();
-            _checkpointManager.Initialize(_detectInput);
+            _checkpointManager.Initialize(_detectInput, _timeManagerViewModel);
             _timeManager.Initialize(_timeManagerViewModel);
             _stateManager.SetState(State.PreGame);
             SetupLeaderboardViews();

--- a/Assets/_BForBoss/_Analytics/Scripts/PerigonAnalytics.cs
+++ b/Assets/_BForBoss/_Analytics/Scripts/PerigonAnalytics.cs
@@ -76,7 +76,7 @@ namespace BForBoss
             Mixpanel.Track(Event.PlayerDeath, props);
         }
 
-        public void LogCheckpointData(float time, String checkpointName)
+        public void LogCheckpointEvent(float time, String checkpointName)
         {
             String formattedTime = string.Format($"{time:0.00}s");
             var props = new Value();

--- a/Assets/_BForBoss/_Analytics/Scripts/PerigonAnalytics.cs
+++ b/Assets/_BForBoss/_Analytics/Scripts/PerigonAnalytics.cs
@@ -78,10 +78,9 @@ namespace BForBoss
 
         public void LogCheckpointEvent(float time, String checkpointName)
         {
-            String formattedTime = string.Format($"{time:0.00}s");
             var props = new Value();
             
-            props[EventAttribute.Time] = formattedTime;
+            props[EventAttribute.Time] = time;
             props[EventAttribute.Course] = EventConstant.RaceCourse;
             props[EventAttribute.Name] = checkpointName;
             Mixpanel.Track(Event.CheckpointReached, props);

--- a/Assets/_BForBoss/_Analytics/Scripts/PerigonAnalytics.cs
+++ b/Assets/_BForBoss/_Analytics/Scripts/PerigonAnalytics.cs
@@ -4,21 +4,25 @@ using mixpanel;
 
 namespace BForBoss
 {
+    #region STRUCTS
     public readonly struct Event
     {
         public const String PlayerDeath = "Player - Death";
+        public const String CheckpointReached = "Checkpoint - Reached";
     }
 
     public readonly struct EventAttribute
     {
         public const String Course = "course";
         public const String Name = "name";
+        public const String Time = "timer";
     }
 
     public readonly struct EventConstant
     {
         public const String RaceCourse = "racecourse";
     }
+    #endregion
 
     public interface IPerigonAnalytics
     {
@@ -39,6 +43,7 @@ namespace BForBoss
 
         public static PerigonAnalytics Instance => _instance;
 
+        #region CONSTRUCTORS
         static PerigonAnalytics()
         {
         }
@@ -46,7 +51,9 @@ namespace BForBoss
         private PerigonAnalytics()
         {
         }
-
+        
+        #endregion
+        
         public void StartSession()
         {
             Mixpanel.Track(SessionStart);
@@ -57,15 +64,30 @@ namespace BForBoss
             Mixpanel.Track(SessionEnd);
             Mixpanel.Flush();
         }
-        
-        public void LogDeathEvent(String name)
+
+        #region CUSTOM EVENTS
+
+        public void LogDeathEvent(String deathAreaName)
         {
             var props = new Value();
             
             props[EventAttribute.Course] = EventConstant.RaceCourse;
-            props[EventAttribute.Name] = name;
+            props[EventAttribute.Name] = deathAreaName;
             Mixpanel.Track(Event.PlayerDeath, props);
         }
+
+        public void LogCheckpointData(float time, String checkpointName)
+        {
+            String formattedTime = string.Format($"{time:0.00}s");
+            var props = new Value();
+            
+            props[EventAttribute.Time] = formattedTime;
+            props[EventAttribute.Course] = EventConstant.RaceCourse;
+            props[EventAttribute.Name] = checkpointName;
+            Mixpanel.Track(Event.CheckpointReached, props);
+        }
+        
+        #endregion
 
         public void LogEvent(String eventName)
         {


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-62

**Description**
- fire an event whenever a player crosses a new checkpoint
- had to list the field as timer because Mixpanel was replacing the time field with their own field (as seen in the screenshot, there is an extra field)

**Screenshots / GIFs**
![image](https://user-images.githubusercontent.com/22460082/139518352-d182cb22-861a-446d-b32f-c373936b0b6e.png)

