### PR TITLE
Rename "Crosshair" assembly to weapons

### DIFF
--- a/Assets/_BForBoss/Tests/Tests.asmdef
+++ b/Assets/_BForBoss/Tests/Tests.asmdef
@@ -11,9 +11,9 @@
         "Unity.PerigonGamesTools",
         "Core",
         "Character",
-        "Crosshair",
         "Utility",
-        "Analytics"
+        "Analytics",
+        "Weapons"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/_BForBoss/_Weapons/Scripts/Weapons.asmdef
+++ b/Assets/_BForBoss/_Weapons/Scripts/Weapons.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Crosshair",
+    "name": "Weapons",
     "rootNamespace": "Perigon.Weapons",
     "references": [
         "GUID:75469ad4d38634e559750d17036d5f7c",


### PR DESCRIPTION

**Description**
Weapons assembly was named "Crosshair", just changed this and fixed references to it

