### PR TITLE
BFB-164: Controller/MKB Sensitivity adjustment

### DIFF
--- a/Assets/_BForBoss/_Character/Scripts/FirstPersonPlayer.InputSettings.cs
+++ b/Assets/_BForBoss/_Character/Scripts/FirstPersonPlayer.InputSettings.cs
@@ -11,8 +11,8 @@ namespace Perigon.Character
         private const string UIActionMapName = "UI";
         
         private const int Default_Is_Inverted = 0;
-        private const float Default_Mouse_Sensitivity = 0.4f;
-        private const float Default_Controller_Sensitivity = 0.4f;
+        private const float Default_Mouse_Sensitivity = 0.05f;
+        private const float Default_Controller_Sensitivity = 0.05f;
 
         private InputActionMap UIActionMap => actions.FindActionMap(UIActionMapName);
         private InputActionMap PlayerControllerActionMap => actions.FindActionMap(PlayerControlActionMapName);

--- a/Assets/_BForBoss/_UserInterface/Scripts/SliderBehaviour.cs
+++ b/Assets/_BForBoss/_UserInterface/Scripts/SliderBehaviour.cs
@@ -12,7 +12,7 @@ namespace Perigon.UserInterface
         /// ECM2's sensitivity normally goes through 0.01 -> 2.0
         /// It looks too small and sensitive, so multiplying by 10 to go through 0.1 -> 25 
         /// </summary>
-        private const float MAPPED_SENSITIVITY_MULTIPLIER = 10f;
+        private const float MAPPED_SENSITIVITY_MULTIPLIER = 100f;
         private Slider _customSlider = null;
         private TMP_InputField _inputField = null;
 


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-164

**Description**
The sensitivity is just too high, set it down and x100 to not have player adjust be the 2 decimal points


