### PR TITLE
Add gitattributes file to enforce line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force mac libraries to use mac line endings
+*.plist text eol=lf


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-182

**Description**
Add a gitattributes file to handle plist files, should prevent the fmod "Incorrect line endings" popup

