### PR TITLE
BFB-196: No Debug Window in Prod Build

### DIFF
--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
@@ -34,6 +34,10 @@ namespace BForBoss
         
         private void Awake()
         {
+#if (!UNITY_EDITOR && !DEVELOPMENT_BUILD)
+            Destroy(gameObject);
+#endif
+            
             if (_instance != null && _instance != this)
             {
                 Destroy(gameObject);


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-196

**Description**
Debug window will now be destroyed if in a scene during Production Build. When we are sure if a WorldManager will be in every scene (which is not currently the case) I will potentially make that handle conditional Instantiation of the prefab.