### PR TITLE
BFB-171 : Automatically close DebugWindow and return character movement after switching scenes

### DIFF
--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugView/SceneSwitcher.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugView/SceneSwitcher.cs
@@ -12,9 +12,11 @@ namespace BForBoss
         
         private List<string> _buildSceneNames = new List<string>();
         private Vector2 _scrollPosition = Vector2.zero;
+        private Action _onSceneSwitched;
 
-        public SceneSwitcher(Rect masterRect) : base(masterRect)
+        public SceneSwitcher(Rect masterRect, Action onSceneSwitched) : base(masterRect)
         {
+            _onSceneSwitched = onSceneSwitched;
             GetBuildSceneNames();
             
 #if UNITY_EDITOR
@@ -66,6 +68,7 @@ namespace BForBoss
         private void ChangeScene(int buildIndex)
         {
             SceneManager.LoadScene(buildIndex, LoadSceneMode.Single);
+            _onSceneSwitched?.Invoke();
         }
 
         private void GetBuildSceneNames()

--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
@@ -70,8 +70,6 @@ namespace BForBoss
                 {
                     OpenPanel();
                 }
-
-                _isPanelShowing = !_isPanelShowing;
             }
         }
 
@@ -108,8 +106,10 @@ namespace BForBoss
                         {
                             if (GUILayout.Button(debugType.Name))
                             {
-                                ConstructorInfo constructorInfo = debugType.GetConstructor(new Type[] {typeof(Rect)});
-                                object[] parameters = new object[] {_windowRect};
+                                ConstructorInfo constructorInfo = debugType.GetConstructors()[0];
+                                object[] parameters = debugType == typeof(SceneSwitcher)
+                                    ? new object[] {_windowRect, (Action)ClosePanel}
+                                    : new object[] {_windowRect};
                                 _currentDebugView = constructorInfo.Invoke(parameters) as DebugView;
                             }
                         }
@@ -140,6 +140,7 @@ namespace BForBoss
             GetCanvasRect();
             transform.localScale = Vector3.one;
             LockMouseUtility.Instance.UnlockMouse();
+            _isPanelShowing = !_isPanelShowing;
         }
 
         private void ClosePanel()
@@ -150,6 +151,7 @@ namespace BForBoss
             transform.localScale = Vector3.zero;
             _stateManager.SetState(_currentState);
             LockMouseUtility.Instance.LockMouse();
+            _isPanelShowing = !_isPanelShowing;
         }
         
         private void GetCanvasRect()


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-171

**Description**
Now, after switching scenes via the Debug Window Scene Switcher, the window will automatically close and the user will have full control of the player!
