### PR TITLE
BFB-396: Changed Enemy Prefab Material

### DIFF
--- a/Assets/_BForBoss/_Entities/Prefabs/FloatingEnemy.prefab
+++ b/Assets/_BForBoss/_Entities/Prefabs/FloatingEnemy.prefab
@@ -173,7 +173,7 @@ SkinnedMeshRenderer:
   m_RenderingLayerMask: 257
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: -6478536213147159724, guid: 2a942f399d48b0c4b92a7d830ff1da2c, type: 3}
+  - {fileID: 2100000, guid: eff95dfd11acc1143ba8f799c4d9ba48, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-396

**Description**
FlyingRobot Enemy Prefab was using a material imported from Blender that might have been causing this bug. I have changed the prefab to use the actual Unity-material instead of the Blender-Material.

