### PR TITLE
BFB-428: Remove Additive Scenes from Scene Switcher Debug Window

### DIFF
--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugView/SceneSwitcherDebugView.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugView/SceneSwitcherDebugView.cs
@@ -79,12 +79,10 @@ namespace BForBoss
             {
                 string buildSceneName = GetAppropriateSceneName(SceneUtility.GetScenePathByBuildIndex(i));
 
-                if (buildSceneName.StartsWith(ADDITIVE_SCENE_PREFIX))
+                if (!buildSceneName.StartsWith(ADDITIVE_SCENE_PREFIX))
                 {
-                    continue;
+                    _buildSceneNames.Add(buildSceneName);
                 }
-                
-                _buildSceneNames.Add(buildSceneName);
             }
         }
 

--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugView/SceneSwitcherDebugView.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugView/SceneSwitcherDebugView.cs
@@ -9,6 +9,7 @@ namespace BForBoss
     {
         private const string SCENE_NAME_DELIMITER = "/";
         private const string SCENE_NAME_EXTENSION = ".unity";
+        private const string ADDITIVE_SCENE_PREFIX = "Additive";
         
         private List<string> _buildSceneNames = new List<string>();
         private Vector2 _scrollPosition = Vector2.zero;
@@ -76,7 +77,14 @@ namespace BForBoss
 
             for (int i = 0; i < SceneManager.sceneCountInBuildSettings; i++)
             {
-                _buildSceneNames.Add(GetAppropriateSceneName(SceneUtility.GetScenePathByBuildIndex(i)));
+                string buildSceneName = GetAppropriateSceneName(SceneUtility.GetScenePathByBuildIndex(i));
+
+                if (buildSceneName.StartsWith(ADDITIVE_SCENE_PREFIX))
+                {
+                    continue;
+                }
+                
+                _buildSceneNames.Add(buildSceneName);
             }
         }
 


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-428

**Description**
Removed additive scenes from showing up in the SceneSwitcher Debug Window by not adding scenes that start with "Additive" (Which is the convention we have softly adopted when creating additive scenes). Though not perfect as it is for the Debug menu it should be fine 

