### PR TITLE
BFB 425: Enemies spawn at their designated Spawn Location instead of 0,0,0

### DIFF
--- a/Assets/_BForBoss/_Core/Scripts/Environment/EnemySpawnAreaBehaviour.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Environment/EnemySpawnAreaBehaviour.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using Perigon.Entities;
 using UnityEngine;
+using UnityEngine.AI;
+
 namespace BForBoss
 {
     public class EnemySpawnAreaBehaviour : MonoBehaviour
@@ -84,8 +86,16 @@ namespace BForBoss
         {
             Debug.Log("<color=red>Spawn Enemy</color>");
             var enemy = _enemyContainer.GetEnemy();
+            
             enemy.OnRelease += HandleOnEnemyReleased;
             enemy.transform.SetPositionAndRotation(transform.position, transform.rotation);
+            enemy.transform.SetParent(transform, true);
+            
+            //https://answers.unity.com/questions/771908/navmesh-issue-with-spawning-players.html
+            NavMeshAgent agent = enemy.GetComponent<NavMeshAgent>();
+            agent.enabled = false;
+            agent.enabled = true;
+            
             _waveModel?.IncrementSpawnCount();
         }
 

--- a/Assets/_BForBoss/_Entities/Scripts/Navigation/AgentNavigationBehaviour.cs
+++ b/Assets/_BForBoss/_Entities/Scripts/Navigation/AgentNavigationBehaviour.cs
@@ -1,8 +1,6 @@
 using System;
-using Perigon.Utility;
 using UnityEngine;
 using UnityEngine.AI;
-using Perigon.Weapons;
 
 namespace Perigon.Entities
 {
@@ -23,20 +21,22 @@ namespace Perigon.Entities
         
         public void MovementUpdate()
         {
-            if (_destination != null)
+            if (_destination == null || !_agent.enabled)
             {
-                var destination = _destination();
+                return;
+            }
+            
+            var destination = _destination();
                 
-                if (Vector3.Distance(transform.position, destination) > _stopDistanceBeforeReachingDestination)
-                {
-                    _agent.isStopped = false;
-                    _agent.destination = destination;
-                }
-                else
-                {
-                    _agent.isStopped = true;
-                    _onDestinationReached?.Invoke();
-                }
+            if (Vector3.Distance(transform.position, destination) > _stopDistanceBeforeReachingDestination)
+            {
+                _agent.isStopped = false;
+                _agent.destination = destination;
+            }
+            else
+            {
+                _agent.isStopped = true;
+                _onDestinationReached?.Invoke();
             }
         }
 


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-425

**Description**
Due to an internal bug with Unity `NavMeshAgent` we have to do a cheap trick to ensure that agents spawn appropriately at runtime. In which, we just have to disable/enable the enemy's `NavMeshAgent` after Instantiating it and setting its transform.

Reference used:
https://answers.unity.com/questions/771908/navmesh-issue-with-spawning-players.html

**Screenshots / GIFs**
![PR attachment](https://user-images.githubusercontent.com/23490604/189526904-af1da871-a028-414d-8fbc-ff72c6ab9956.gif)


