### PR TITLE
BFB-415: Created Fade-to-Black Pass 

### DIFF
--- a/Assets/_BForBoss/_Core/Prefabs/PostProcessingVolume.prefab
+++ b/Assets/_BForBoss/_Core/Prefabs/PostProcessingVolume.prefab
@@ -99,7 +99,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2228368853135509604}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1744428414
 MonoBehaviour:
@@ -148,7 +148,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2228368853135509604}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5335462424936513040
 MonoBehaviour:
@@ -167,6 +167,75 @@ MonoBehaviour:
   blendDistance: 0
   weight: 0
   sharedProfile: {fileID: 11400000, guid: 0f04cac1ddc1e4a32a0834ea6da938da, type: 2}
+--- !u!1 &2162381925823319219
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8494695288366397604}
+  - component: {fileID: 3340144122088033037}
+  m_Layer: 0
+  m_Name: FadeToBlackCustomPassVolume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8494695288366397604
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2162381925823319219}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.8698356, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2228368853135509604}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3340144122088033037
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2162381925823319219}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26d6499a6bd256e47b859377446493a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 0
+  fadeRadius: 0
+  priority: 0
+  customPasses:
+  - rid: 7551373383550369792
+  injectionPoint: 2
+  m_TargetCamera: {fileID: 0}
+  useTargetCamera: 1
+  references:
+    version: 2
+    RefIds:
+    - rid: 7551373383550369792
+      type: {class: FullScreenCustomPass, ns: UnityEngine.Rendering.HighDefinition, asm: Unity.RenderPipelines.HighDefinition.Runtime}
+      data:
+        m_Name: Custom Pass
+        enabled: 1
+        targetColorBuffer: 0
+        targetDepthBuffer: 0
+        clearFlags: 0
+        passFoldout: 0
+        m_Version: 0
+        fullscreenPassMaterial: {fileID: 2100000, guid: f4c1d49541edfe448a089c05b54be698, type: 2}
+        materialPassIndex: 0
+        materialPassName: Custom Pass 1
+        fetchColorBuffer: 0
 --- !u!1 &2424747464914641520
 GameObject:
   m_ObjectHideFlags: 0
@@ -236,55 +305,6 @@ MonoBehaviour:
         materialPassIndex: 0
         materialPassName: Custom Pass 1
         fetchColorBuffer: 0
---- !u!1 &7808378451213904285
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7044683664954896734}
-  - component: {fileID: 505340287595307692}
-  m_Layer: 0
-  m_Name: DeathPostProcessingVolume
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7044683664954896734
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7808378451213904285}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2228368853135509604}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &505340287595307692
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7808378451213904285}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IsGlobal: 1
-  priority: 0
-  blendDistance: 0
-  weight: 0
-  sharedProfile: {fileID: 11400000, guid: 4dc6ad37a1963474db7e6ca9411133dd, type: 2}
 --- !u!1 &8667732873925327994
 GameObject:
   m_ObjectHideFlags: 0
@@ -317,9 +337,9 @@ Transform:
   m_Children:
   - {fileID: 361606539}
   - {fileID: 51444252771771736}
+  - {fileID: 8494695288366397604}
   - {fileID: 1744428413}
   - {fileID: 1937951370922037463}
-  - {fileID: 7044683664954896734}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -339,7 +359,7 @@ MonoBehaviour:
   _healPassVolume: {fileID: 7958165691405958548}
   _slowMotionVolume: {fileID: 1744428414}
   _dashVolume: {fileID: 5335462424936513040}
-  _deathVolume: {fileID: 505340287595307692}
+  _deathVolume: {fileID: 3340144122088033037}
 --- !u!114 &2654312843269189473
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack.meta
+++ b/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d46a5de231f035942adc83d71cfe846c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/M_FadeToBlack.mat
+++ b/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/M_FadeToBlack.mat
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: M_FadeToBlack
+  m_Shader: {fileID: 4800000, guid: 8e3acf69bea722147a9b71bfee450f40, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _EmissionStrength: 0.71
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/M_FadeToBlack.mat.meta
+++ b/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/M_FadeToBlack.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4c1d49541edfe448a089c05b54be698
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/S_FadeToBlackEffect.shader
+++ b/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/S_FadeToBlackEffect.shader
@@ -1,0 +1,64 @@
+Shader "FullScreen/S_FadeToBlackEffect"
+{
+    Properties{
+        _EmissionStrength("Emission Strength", float) = 1.0
+        }
+
+    HLSLINCLUDE
+
+    #pragma vertex Vert
+
+    #pragma target 4.5
+    #pragma only_renderers d3d11 playstation xboxone xboxseries vulkan metal switch
+
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/CustomPass/CustomPassCommon.hlsl"
+
+    float _EmissionStrength;
+
+    
+    float4 FullScreenPass(Varyings varyings) : SV_Target
+    {
+        UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(varyings);
+        float depth = LoadCameraDepth(varyings.positionCS.xy);
+        PositionInputs posInput = GetPositionInput(varyings.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V);
+        float3 viewDirection = GetWorldSpaceNormalizeViewDir(posInput.positionWS);
+        float4 color = float4(0.0, 0.0, 0.0, 0.0);
+
+        // Load the camera color buffer at the mip 0 if we're not at the before rendering injection point
+        if (_CustomPassInjectionPoint != CUSTOMPASSINJECTIONPOINT_BEFORE_RENDERING)
+            color = float4(CustomPassLoadCameraColor(varyings.positionCS.xy, 0), 1);
+        
+        
+        if (_EmissionStrength > 1)
+        {
+            _EmissionStrength = 1;
+        }
+        if (_EmissionStrength < 0)
+        {
+            _EmissionStrength = 0;
+        }
+        
+        return half4(0.0, 0.0, 0.0, _EmissionStrength);
+    }
+
+    ENDHLSL
+
+    SubShader
+    {
+        Tags{ "RenderPipeline" = "HDRenderPipeline" }
+        Pass
+        {
+            Name "Fade Black Pass"
+
+            ZWrite Off
+            ZTest Always
+            Blend SrcAlpha OneMinusSrcAlpha
+            Cull Off
+
+            HLSLPROGRAM
+                #pragma fragment FullScreenPass
+            ENDHLSL
+        }
+    }
+    Fallback Off
+}

--- a/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/S_FadeToBlackEffect.shader.meta
+++ b/Assets/_BForBoss/_Shaders/FullScreenShaders/FadeToBlack/S_FadeToBlackEffect.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8e3acf69bea722147a9b71bfee450f40
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_BForBoss/_Utility/Scripts/VisualEffectsManager.cs
+++ b/Assets/_BForBoss/_Utility/Scripts/VisualEffectsManager.cs
@@ -40,6 +40,7 @@ namespace Perigon.Utility
             _instance = this;
             _damageTakenPassVolume.targetCamera = _mainCamera;
             _healPassVolume.targetCamera = _mainCamera;
+            _deathVolume.targetCamera = _mainCamera;
             _damageTakenVFXTool = new CustomPassVolumeWeightTool(_damageTakenPassVolume, EMISSION_STRENGTH_KEY);
             _healVFXTool = new CustomPassVolumeWeightTool(_healPassVolume, EMISSION_STRENGTH_KEY);
             _slowMotionVFXTool = new PostProcessingVolumeWeightTool(_slowMotionVolume);

--- a/Assets/_BForBoss/_Utility/Scripts/VisualEffectsManager.cs
+++ b/Assets/_BForBoss/_Utility/Scripts/VisualEffectsManager.cs
@@ -24,7 +24,7 @@ namespace Perigon.Utility
         [Resolve][SerializeField] private CustomPassVolume _healPassVolume;
         [Resolve][SerializeField] private Volume _slowMotionVolume;
         [Resolve][SerializeField] private Volume _dashVolume;
-        [Resolve][SerializeField] private Volume _deathVolume;
+        [Resolve][SerializeField] private CustomPassVolume _deathVolume;
         private IVolumeWeightTool _damageTakenVFXTool;
         private IVolumeWeightTool _healVFXTool;
         private IVolumeWeightTool _slowMotionVFXTool;
@@ -44,7 +44,7 @@ namespace Perigon.Utility
             _healVFXTool = new CustomPassVolumeWeightTool(_healPassVolume, EMISSION_STRENGTH_KEY);
             _slowMotionVFXTool = new PostProcessingVolumeWeightTool(_slowMotionVolume);
             _dashVFXTool = new PostProcessingVolumeWeightTool(_dashVolume);
-            _deathVFXTool = new PostProcessingVolumeWeightTool(_deathVolume);
+            _deathVFXTool = new CustomPassVolumeWeightTool(_deathVolume, EMISSION_STRENGTH_KEY);
         }
         
         public void DistortAndRevert(HUDVisualEffect effect)


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-415

**Description**
Created a CustomVolumePass called FadeToBlackCustomVolumePass in the PostProcessingVolume prefab.

I changed what-I-think-to-be the appropriate code in the Visual Effects Manager script to change the death Volume to type CustomVolumePass. (This may have been done incorrectly, so please let me know if that is the case.)

As per usual, the intensity of this custom pass can be controlled by a single value. 0 means no black, 1 means full black.

NOTE: Because of how CustomVolumePasses work, I was unable to find a way to also blackout the UI and the weapon. Further investigations may need to be done to figure out the best way go about having the UI and weapon not show up on a fade-to-black as I am not 100% sure how the UI and Weapon are being renderer currently.
