### PR TITLE
BFB-443: BugFix Ensure Slider Input Field text matches Slider Value

### DIFF
--- a/Assets/_BForBoss/_UserInterface/Scripts/SliderBehaviour.cs
+++ b/Assets/_BForBoss/_UserInterface/Scripts/SliderBehaviour.cs
@@ -43,8 +43,12 @@ namespace Perigon.UserInterface
         public float SliderValue
         {
              get=> CustomSlider.value;
-             
-             set => CustomSlider.value = value;
+
+             set
+             {
+                 CustomSlider.value = value;
+                 CustomInputField.text = value.ToString(FormatString);
+             }
         }
 
         private string FormatString => _wholeNumbers ? "F0" : "F";

--- a/Assets/_BForBoss/_Utility/Scripts/PlayerPrefKeys.cs
+++ b/Assets/_BForBoss/_Utility/Scripts/PlayerPrefKeys.cs
@@ -16,13 +16,6 @@ namespace Perigon.Utility
             public const string CONTROLLER_VERTICAL_SENSITIVITY = "controller_vertical_sensitivity";
         }
 
-        public struct LeaderboardSettings
-        {
-            public const string USERNAME = "user_name";
-            public const string TIMER = "timer";
-            public const string SHOULD_UPLOAD = "should_upload";
-        }
-
         public struct AudioSettings
         {
             public const string MAIN_VOLUME = "main_volume";
@@ -33,7 +26,6 @@ namespace Perigon.Utility
         public static IList<string> GetAllKeys()
         {
             var keys = GetConstStringValuesFromStruct<InputSettings>().ToList();
-            keys.AddRange(GetConstStringValuesFromStruct<LeaderboardSettings>());
             keys.AddRange(GetConstStringValuesFromStruct<AudioSettings>());
             return keys;
         }


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-443

**Description**
Added functionality onto `SliderValue `setter so that the inputText would match to SliderValue that have been set via `PlayerPrefs`

