### PR TITLE
Ensure no MeshGeneration takes place outside root folder

### DIFF
--- a/Assets/_BForBoss/_Utility/Scripts/Editor/MaterialGenerationAssetPostProcessor/MaterialGenerationAssetPostProcessor.cs
+++ b/Assets/_BForBoss/_Utility/Scripts/Editor/MaterialGenerationAssetPostProcessor/MaterialGenerationAssetPostProcessor.cs
@@ -27,6 +27,13 @@ public class MaterialGenerationAssetPostProcessor : AssetPostprocessor
 
     private void OnPreprocessTexture()
     {
+        //Does not apply for script outside the BForBoss root folder
+        //Assumes the root namespace will be in root folder name
+        if (!assetPath.Contains(EditorSettings.projectGenerationRootNamespace))
+        {
+            return;
+        }
+        
         string extension = string.Empty;
         foreach (string fileExtension in TEXTURE_FILE_EXTENSIONS)
         {


### PR DESCRIPTION
**Description**
Related issue: https://b-boss-crew.slack.com/archives/C023CJZMRS8/p1664029256942989

Solution: Ensure that our material generation process only takes place for images within the `_BForBoss` folder. Since we can't know what images (or their naming conventions) are being used by external assets (outside our core folder).

