### PR TITLE
Add Debug Functionality to EnergySystem

### DIFF
--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
@@ -18,6 +18,7 @@ namespace BForBoss
         [SerializeField] private FreeRoamCamera _freeRoamCamera = null;
         
         private PlayerLifeCycleBehaviour _playerLifeCycle;
+        private EnergySystemBehaviour _energySystemBehaviour;
         private bool _isPlayerCurrentlyInvincible;
         
         //State Handling
@@ -48,6 +49,7 @@ namespace BForBoss
             
             _freeRoamCamera.Initialize(Camera.main.transform, onExit: OnFreeCameraDebugViewExited);
             _playerLifeCycle = FindObjectOfType<PlayerLifeCycleBehaviour>();
+            _energySystemBehaviour = FindObjectOfType<EnergySystemBehaviour>();
         }
 
         private void Update()
@@ -120,6 +122,12 @@ namespace BForBoss
                 {
                     GUILayout.Space(0.15f * _windowRect.height);
                     _playerLifeCycle.IsInvincible = DrawDebugToggle(_playerLifeCycle.IsInvincible, new GUIContent("Player Invincibility"));
+                    _energySystemBehaviour.UseDebugEnergyCost = DrawDebugToggle(_energySystemBehaviour.UseDebugEnergyCost, new GUIContent("Freeze Energy Cost"));
+
+                    if (GUILayout.Button("Give Max Energy"))
+                    {
+                        _energySystemBehaviour.SetMaxEnergy();
+                    }
                 }
                     
                 GUILayout.FlexibleSpace();

--- a/Assets/_BForBoss/_Core/Scripts/EnergySystem/EnergySystemBehaviour.Debug.cs
+++ b/Assets/_BForBoss/_Core/Scripts/EnergySystem/EnergySystemBehaviour.Debug.cs
@@ -1,0 +1,14 @@
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+namespace BForBoss
+{
+    public partial class EnergySystemBehaviour
+    {
+        public bool UseDebugEnergyCost = false;
+
+        public void SetMaxEnergy()
+        {
+            EnergyData = _energyData.Apply(_energyData.MaxEnergyValue);
+        }
+    }
+}
+#endif

--- a/Assets/_BForBoss/_Core/Scripts/EnergySystem/EnergySystemBehaviour.Debug.cs.meta
+++ b/Assets/_BForBoss/_Core/Scripts/EnergySystem/EnergySystemBehaviour.Debug.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74ddf908b397857488c86d9b5473918e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_BForBoss/_Core/Scripts/EnergySystem/EnergySystemBehaviour.cs
+++ b/Assets/_BForBoss/_Core/Scripts/EnergySystem/EnergySystemBehaviour.cs
@@ -179,6 +179,13 @@ namespace BForBoss
         
         private float MapToExpendValue(EnergyExpenseType type, float multiplier)
         {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            if (UseDebugEnergyCost)
+            {
+                return 0.0f;
+            }
+#endif
+            
             switch (type)
             {
                 case EnergyExpenseType.Shot:
@@ -187,7 +194,7 @@ namespace BForBoss
                     return _energySystemConfigurationData.SlowMoEnergy * multiplier;
                 default:
                     PanicHelper.Panic(new Exception("Missing Case for MapToExpendValue"));
-                    return 0;
+                    return 0.0f;
             }
         }
     }


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-477

**Description**
Gave the players the ability to freeze costs (i.e. make everything cost 0 energy). They can technically have infinite energy when needed but can then toggle back to the same amount of energy they had earlier when desired. 

It also made a quick and easy method to allow players to give themselves a full amount of energy. To make testing easier


