### PR TITLE
Ensure Debug window only works in Editor and Development Builds

### DIFF
--- a/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Debug/DebugWindow.cs
@@ -9,6 +9,7 @@ namespace BForBoss
 {
     public class DebugWindow : MonoBehaviour
     {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
         private const Key KEYCODE_CHARACTER = Key.Backquote;
 
         private const float CANVAS_WIDTH_MULTIPLIER = 0.2f;
@@ -123,7 +124,6 @@ namespace BForBoss
                     GUILayout.Space(0.15f * _windowRect.height);
                     _playerLifeCycle.IsInvincible = DrawDebugToggle(_playerLifeCycle.IsInvincible, new GUIContent("Player Invincibility"));
                     _energySystemBehaviour.UseDebugEnergySystemConfig = DrawDebugToggle(_energySystemBehaviour.UseDebugEnergySystemConfig, new GUIContent("Freeze Energy"));
-
                     if (GUILayout.Button("Give Max Energy"))
                     {
                         _energySystemBehaviour.SetMaxEnergy();
@@ -231,5 +231,6 @@ namespace BForBoss
                 _currentDebugView.MasterRect = _windowRect;
             }
         }
+#endif
     }
 }


### PR DESCRIPTION


**Description**
We had an issue in building Prod builds because I was referencing a Debug/Development only variable `EnergySystemBehaviour.UseDebugEnergySystemConfig` in DebugWindow.

The solution, a long time coming, is just to ensure any logic within the Debug Window is set in Editor and Development builds

