### PR TITLE
BFB-549: Update labor system to work better with context manager

### DIFF
--- a/Assets/_BForBoss/Tests/LaborSystemTests.cs
+++ b/Assets/_BForBoss/Tests/LaborSystemTests.cs
@@ -18,7 +18,7 @@ namespace Tests.Labors
             var array = new ILabor[] {mock1, mock2, mock3, mock4};
 
             // When
-            var system = new LaborSystem(array);
+            var system = new LaborSystem(array, autoStart: true);
             
             // Then
             Assert.IsTrue(mock1.IsActivated);
@@ -37,7 +37,7 @@ namespace Tests.Labors
             var array = new ILabor[] {mock1, mock2, mock3, mock4};
 
             // When
-            var system = new LaborSystem(array);
+            var system = new LaborSystem(array, autoStart: true);
             mock1.CompleteLabor();
             
             // Then
@@ -56,7 +56,7 @@ namespace Tests.Labors
             var array = new ILabor[] {mock1, mock2, mock3, mock4};
 
             // When
-            var system = new LaborSystem(array);
+            var system = new LaborSystem(array, autoStart: true);
             mock1.CompleteLabor();
             mock2.CompleteLabor();
             mock3.CompleteLabor();
@@ -78,7 +78,7 @@ namespace Tests.Labors
             var array = new ILabor[] {mock1, mock2, mock3, mock4};
 
             // When
-            var system = new LaborSystem(array);
+            var system = new LaborSystem(array, autoStart: true);
             mock1.CompleteLabor();
             mock3.CompleteLabor();
             mock4.CompleteLabor();

--- a/Assets/_BForBoss/Tests/Mocks/MockLabor.cs
+++ b/Assets/_BForBoss/Tests/Mocks/MockLabor.cs
@@ -10,7 +10,7 @@ namespace Tests
     {
         public bool IsActivated { get; private set; }
         
-        public event Action OnLaborCompleted;
+        public event Action<bool> OnLaborCompleted;
         
         public MockLabor()
         {
@@ -26,7 +26,7 @@ namespace Tests
         {
             if (IsActivated)
             {
-                OnLaborCompleted?.Invoke();
+                OnLaborCompleted?.Invoke(true);
             }
         }
         

--- a/Assets/_BForBoss/_Core/Scripts/Boss/DerekContextManager.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Boss/DerekContextManager.cs
@@ -85,7 +85,7 @@ namespace BForBoss
                 case Phase.Tutorial:
                     //TutorialEndButton.UnBind();
                     _currentPhase = Phase.FirstPhase;
-                    _ringLaborManager.Initialize(OnLaborCompleted);
+                    _ringLaborManager.ActivateSystem(OnLaborCompleted);
                     break;
                 case Phase.FirstPhase:
                     _currentPhase = Phase.SecondPhase;
@@ -98,8 +98,7 @@ namespace BForBoss
                 default:
                     break;
             }
-
-            _ringLaborManager.Reset();
+            
             _bossManager.UpdatePhase(_currentPhase);
             _bossManager.UpdateVulnerability(Vulnerability.Invulnerable);
         }

--- a/Assets/_BForBoss/_Core/Scripts/Labor/ILabor.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Labor/ILabor.cs
@@ -4,7 +4,7 @@ namespace BForBoss.Labor
 {
     public interface ILabor
     {
-        public event Action OnLaborCompleted;
+        public event Action<bool> OnLaborCompleted;
 
         public void Activate();
 

--- a/Assets/_BForBoss/_Core/Scripts/Labor/RingSystem/RingBehaviour.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Labor/RingSystem/RingBehaviour.cs
@@ -6,7 +6,7 @@ namespace BForBoss.RingSystem
 {
     public class RingBehaviour : MonoBehaviour
     {
-        public event Action<RingBehaviour> RingActivated;
+        public Action<RingBehaviour> RingActivated;
         
         [SerializeField] private int _label;
 
@@ -33,7 +33,7 @@ namespace BForBoss.RingSystem
             RingActivated?.Invoke(this);
         }
 
-        private void SetLabel(string label)
+        public void SetLabel(string label)
         {
             _labelTMP.text = label;
         }

--- a/Assets/_BForBoss/_Core/Scripts/Labor/RingSystem/RingLaborManager.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Labor/RingSystem/RingLaborManager.cs
@@ -25,16 +25,23 @@ namespace BForBoss.RingSystem
                 system.Reset();
             }
 
+            if (CountdownTimer.Instance.IsRunning) CountdownTimer.Instance.ToggleCountdown();
+
             _laborSystem?.Dispose();
             _laborSystem = new LaborSystem(_ringSystems, false);
             _hasCompletedSystem = false;
         }
         
-        public void Initialize(Action onLaborCompleted)
+        public void Initialize()
         {
-            _onLaborCompleted = onLaborCompleted;
             CreateSystems();
             _laborSystem = new LaborSystem(_ringSystems, false);
+        }
+
+        public void ActivateSystem(Action onLaborComplete)
+        {
+            _onLaborCompleted = onLaborComplete;
+            _laborSystem?.Start();
         }
 
         public void ToggleTimer()
@@ -56,12 +63,12 @@ namespace BForBoss.RingSystem
                         nestedSystems[i] = BuildFromGrouping(grouping.NestedSystems[i], -1f);
                     }
                     newSystem = new NestedRingSystem(nestedSystems, true, grouping.Time);
-                    newSystem.OnLaborCompleted += () => Perigon.Utility.Logger.LogString($"Completed {grouping.NestedSystems.Length} system {grouping.RingSystemType} system", key:"Labor");
+                    newSystem.OnLaborCompleted += (success) => Perigon.Utility.Logger.LogString($"{(success ? "Completed" : "Failed")} {grouping.NestedSystems.Length} system {grouping.RingSystemType} system", key:"Labor");
                 }
                 else
                 {
                     newSystem = BuildFromGrouping(grouping);
-                    newSystem.OnLaborCompleted += () => Perigon.Utility.Logger.LogString($"Completed {grouping.Rings.Length} ring {grouping.RingSystemType} system", key:"Labor");
+                    newSystem.OnLaborCompleted += (success) => Perigon.Utility.Logger.LogString($"{(success ? "Completed" : "Failed")} {grouping.Rings.Length} ring {grouping.RingSystemType} system", key:"Labor");
                 }
                 _ringSystems.Add(newSystem);
             }

--- a/Assets/_BForBoss/_Core/Scripts/Labor/RingSystem/RingSystem.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Labor/RingSystem/RingSystem.cs
@@ -7,7 +7,7 @@ namespace BForBoss.RingSystem
 {
     public class RingSystem : ILabor
     {
-        public event Action OnLaborCompleted;
+        public event Action<bool> OnLaborCompleted;
         private RingBehaviour _currentRing;
         private Queue<RingBehaviour> _ringQueue;
         private readonly RingBehaviour[] _allRings;
@@ -17,18 +17,16 @@ namespace BForBoss.RingSystem
         
         private readonly float _time;
 
+        private int _ringIndex = 1;
+
         public RingSystem(RingBehaviour[] rings, bool isRandomized = false, bool allAtOnce = false, float time = 0f)
         {
             _allRings = rings;
             _isRandomized = isRandomized;
             _allAtOnce = allAtOnce;
             _time = time;
-            SetupRingLists(_allRings);
-
-            foreach (var ring in _allRings)
-            {
-                ring.gameObject.SetActive(false);
-            }
+            
+            Reset();
         }
 
         public void Reset()
@@ -40,6 +38,7 @@ namespace BForBoss.RingSystem
 
             _currentRing = null;
             SetupRingLists(_allRings);
+            _ringIndex = 1;
         }
 
         public void Activate()
@@ -79,18 +78,19 @@ namespace BForBoss.RingSystem
         {
             Perigon.Utility.Logger.LogString("Ran out of time! Resetting the labor", key: "Labor");
             Reset();
-            Activate();
+            OnLaborCompleted?.Invoke(false);
         }
 
         private void DeactivateRing(RingBehaviour ring)
         {
             ring.gameObject.SetActive(false);
-            ring.RingActivated -= RingTriggered;
+            ring.RingActivated = null;
         }
 
         private void ActivateRing(RingBehaviour ring)
         {
-            ring.RingActivated += RingTriggered;
+            ring.RingActivated = RingTriggered;
+            ring.SetLabel(_ringIndex++.ToString());
             ring.gameObject.SetActive(true);
         }
         
@@ -109,7 +109,7 @@ namespace BForBoss.RingSystem
         {
             if(_time > 0f)
                 CountdownTimer.Instance.StopCountdown();
-            OnLaborCompleted?.Invoke();
+            OnLaborCompleted?.Invoke(true);
         }
     }
 }

--- a/Assets/_BForBoss/_Core/Scripts/Managers/SandboxWorldManager.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Managers/SandboxWorldManager.cs
@@ -27,7 +27,7 @@ namespace BForBoss
         protected override void Start()
         {
             base.Start();
-            _ringLaborManager.Initialize(null);
+            _ringLaborManager.Initialize();
             _wipeOutWallsManager.Initialize(_playerBehaviour.PlayerMovement);
             _derekMissileLauncherBehaviours.ForEach(launcher => launcher.Initialize(_playerBehaviour.PlayerMovement));
         }


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-549

**Description**
Labor system is now fully controlled by the context manager. Note that this has some caveats: The rings will not appear until after the first phase is started (using the debug button on the context manager)
Initialization & starting are now different operations
Resetting no longer re activates the system. Note that resetting now soft locks the game, since the context manager only starts the ring system on phase 1 and resetting doesn't reset the current phase
Ring labels are set dynamically, within each ring system. Each system will start with ring 1. 


