### PR TITLE
BFB-602 : Shrink Floor as Phase increases

### DIFF
--- a/Assets/_BForBoss/_Core/Prefabs/Boss_Derek/DerekPhase_1.asset
+++ b/Assets/_BForBoss/_Core/Prefabs/Boss_Derek/DerekPhase_1.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   _healthThreshold: 0.75
   _healthBarColor: {r: 0.24554875, g: 0.9622642, b: 0.031772893, a: 1}
   _vulnerabilityDuration: 10
+  _floorSizeScale: 1
   _rotationRate: 25
   _intervalBetweenShots: 5
   _missileSpeedMultiplier: 60

--- a/Assets/_BForBoss/_Core/Prefabs/Boss_Derek/DerekPhase_2.asset
+++ b/Assets/_BForBoss/_Core/Prefabs/Boss_Derek/DerekPhase_2.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   _healthThreshold: 0.25
   _healthBarColor: {r: 1, g: 0.5185517, b: 0, a: 1}
   _vulnerabilityDuration: 10
+  _floorSizeScale: 0.8
   _rotationRate: 30
   _intervalBetweenShots: 3
   _missileSpeedMultiplier: 60

--- a/Assets/_BForBoss/_Core/Prefabs/Boss_Derek/DerekPhase_3.asset
+++ b/Assets/_BForBoss/_Core/Prefabs/Boss_Derek/DerekPhase_3.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
   _healthThreshold: 0
   _healthBarColor: {r: 1, g: 0, b: 0, a: 1}
   _vulnerabilityDuration: 5
+  _floorSizeScale: 0.7
   _rotationRate: 50
   _intervalBetweenShots: 2
   _missileSpeedMultiplier: 60

--- a/Assets/_BForBoss/_Core/Scripts/Boss/DerekContextManager.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Boss/DerekContextManager.cs
@@ -27,7 +27,7 @@ namespace BForBoss
         [SerializeField, InlineEditor] private DerekPhaseDataSO _finalPhaseData;
 
         //RingLabors configurations
-        [Title("Ring Configurations")] 
+        [Header("Ring Configurations")] 
         
         [Header("Phase 1")]
         [SerializeField]
@@ -40,6 +40,7 @@ namespace BForBoss
         private RingGrouping _ringConfigurationsFinalPhase;
         
         private DerekPhaseDataSO _currentPhaseDataSO = null;
+        private Vector3 _originalFloorScale;
 
         public enum Phase
         {
@@ -61,7 +62,7 @@ namespace BForBoss
 
         public void Reset()
         {
-            _floorTransform.localScale = Vector3.one;
+            _floorTransform.localScale = _originalFloorScale;
             _ringLaborManager.Reset();
             _currentPhase = Phase.Tutorial;
             _currentVulnerability = Vulnerability.Invulnerable;
@@ -130,7 +131,9 @@ namespace BForBoss
             }
 
             float floorScale = _currentPhaseDataSO.FloorSizeScale;
-            DOTween.To(() => _floorTransform.localScale, floorScaleVector => _floorTransform.localScale = floorScaleVector, new Vector3(floorScale, 1, floorScale), _floorScaleTweenDuration);
+            DOTween.To(() => _floorTransform.localScale, floorScaleVector => _floorTransform.localScale = floorScaleVector, 
+                new Vector3(floorScale * _originalFloorScale.x, _originalFloorScale.y, floorScale * _originalFloorScale.z),
+                _floorScaleTweenDuration);
             
             _ringLaborManager.ActivateSystem();
             _currentVulnerability = Vulnerability.Invulnerable;
@@ -153,6 +156,7 @@ namespace BForBoss
             {
                 PanicHelper.Panic(new Exception("Floor object has not been set"));
             }
+            _originalFloorScale = _floorTransform.localScale;
 
             // Data
             this.PanicIfNullObject(_firstPhaseData, nameof(_firstPhaseData));

--- a/Assets/_BForBoss/_Core/Scripts/Boss/DerekPhaseDataSO.cs
+++ b/Assets/_BForBoss/_Core/Scripts/Boss/DerekPhaseDataSO.cs
@@ -13,6 +13,10 @@ namespace BForBoss
         [SerializeField, ColorPalette, Tooltip("The color of the healthbar during this phase")]
         private Color _healthBarColor;
         [SerializeField, MinValueAttribute(0.0f), Tooltip("How long should Derek's vulnerability last this phase")] private float _vulnerabilityDuration = 1.0f;
+
+        [Header("Environment")]
+        [SerializeField, MinValueAttribute(0.0f), MaxValueAttribute(1.0f), Tooltip("The Scale (x and z) of the Floor")]
+        private float _floorSizeScale = 1.0f;
         
         //Movement
         [Header("Movement")]
@@ -26,6 +30,8 @@ namespace BForBoss
         public float HealthThreshold => _healthThreshold;
         public Color HealthBarColor => _healthBarColor;
         public float VulnerabilityDuration => _vulnerabilityDuration;
+
+        public float FloorSizeScale => _floorSizeScale;
         
         public float RotationRate => _rotationRate;
         

--- a/Assets/_BForBoss/_LevelDesign/Scenes/DerekFlowSandbox.unity
+++ b/Assets/_BForBoss/_LevelDesign/Scenes/DerekFlowSandbox.unity
@@ -1784,7 +1784,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalScale.x
-      value: 50
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalScale.y
@@ -1792,11 +1792,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalScale.z
-      value: 20
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -115
+      value: -70.3
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1804,7 +1804,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -55
+      value: -74.5
       objectReference: {fileID: 0}
     - target: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1891,22 +1891,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d900f19c2e993d24a877c05e0c7a69ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _endTutorialButton: {fileID: 575480701}
   _bossManager: {fileID: 730369066}
   _ringLaborManager: {fileID: 1386954919}
+  _endTutorialButton: {fileID: 575480701}
+  _floorTransform: {fileID: 1153959254}
+  _floorScaleTweenDuration: 6
   _firstPhaseData: {fileID: 11400000, guid: 0912f91036cf5754da0c0cfb69adba84, type: 2}
   _secondPhaseData: {fileID: 11400000, guid: 0b0234d4998caae4b82296a115c55391, type: 2}
   _finalPhaseData: {fileID: 11400000, guid: c8a21024e30f9204f98ac20d5a2e6b94, type: 2}
-  _ringConfigurationsTutorial:
-    TimeToComplete: 15
-    GroupOfRings:
-    - Rings:
-      - {fileID: 1165508692}
-      - {fileID: 414869636}
-    - Rings:
-      - {fileID: 773150892}
-      - {fileID: 2140514098}
-    RingColor: {r: 0.24279505, g: 0.754717, b: 0.17443931, a: 0}
   _ringConfigurationsFirstPhase:
     TimeToComplete: 15
     GroupOfRings:
@@ -1933,6 +1925,20 @@ MonoBehaviour:
       - {fileID: 414869636}
       - {fileID: 1165508692}
     RingColor: {r: 1, g: 0, b: 0.9449339, a: 0}
+  _ringConfigurationsFinalPhase:
+    TimeToComplete: 15
+    GroupOfRings:
+    - Rings:
+      - {fileID: 773150892}
+      - {fileID: 2140514098}
+      - {fileID: 1580725701}
+      - {fileID: 414869636}
+    - Rings:
+      - {fileID: 2140514098}
+      - {fileID: 1580725701}
+      - {fileID: 414869636}
+      - {fileID: 1165508692}
+    RingColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!4 &787198327
 Transform:
   m_ObjectHideFlags: 0
@@ -2112,6 +2118,11 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!4 &1153959254 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8038010192155406783, guid: 8e909bed7ecada04886127e462577d2d, type: 3}
+  m_PrefabInstance: {fileID: 671225812}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1165508691
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
**JIRA Ticket**
https://perigongames.atlassian.net/browse/BFB-602

**Description**
Designers now can change the floor size (multiplier between 0 and 1) as part of the per per-phase data structure. The floor tweens to the designated scale (only x and z scale) within a given amount of time (so that players have enough time to react to the change).

The idea is to make traversal via the floor harder during the Derke Boss fight as the phases progress. We should add more bounce pads on the Floor level (harder to land on)

**Screenshots / GIFs**

https://github.com/PerigonGames/BForBoss/assets/23490604/c240326f-de9e-4af5-afd6-d7ccdf34830c



![Floor Duration](https://github.com/PerigonGames/BForBoss/assets/23490604/5ce35d59-a931-47d7-8ca9-0acf43b92084)
![Floor Scale](https://github.com/PerigonGames/BForBoss/assets/23490604/22328d6a-2c15-48e5-81c2-71262e80d417)
